### PR TITLE
fix: gateway binary path and boot enable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,7 @@ Environment=OPENCLAW_HOME=/home/openclaw
 Environment=TENANT_ID=${TENANT_ID}
 Environment=PATH=/opt/pesuclaw/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=-/etc/openclaw/env
-ExecStart=$(which openclaw 2>/dev/null || echo "/usr/local/bin/openclaw") gateway
+ExecStart=/usr/bin/openclaw gateway
 Restart=always
 RestartSec=10
 StandardOutput=journal
@@ -228,6 +228,7 @@ EOF
 # ── 9. Enable timers and services ──────────────────────────────────
 systemctl daemon-reload
 systemctl enable --now cloud-sql-proxy
+systemctl enable openclaw.service
 systemctl enable pesuclaw-sync.timer
 systemctl start pesuclaw-sync.timer
 systemctl enable pesuclaw-update.timer

--- a/sync.sh
+++ b/sync.sh
@@ -315,7 +315,7 @@ $include_lines
   "gateway": {
     "mode": "local",
     "port": 8080,
-    "bind": "0.0.0.0",
+    "bind": "lan",
     "auth": {
       "mode": "token",
       "token": "\${OPENCLAW_GATEWAY_TOKEN}"


### PR DESCRIPTION
## Summary
- Fix ExecStart path: `/usr/bin/openclaw` instead of `$(which openclaw)` fallback
- Enable `openclaw.service` on boot so gateway starts automatically
- Fix `gateway.bind` from `"0.0.0.0"` (legacy) to `"lan"` in sync.sh config template

Resolves the MIG auto-heal loop caused by health check failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)