### PR TITLE
feat: add Docker for OpenClaw sandbox

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,17 @@ echo ">>> Installing base dependencies..."
 apt-get update -qq
 apt-get install -y -qq curl git jq
 
-# ── 2. Tailscale VPN ──────────────────────────────────────────────
+# ── 2. Docker (required for OpenClaw sandbox) ─────────────────────
+if ! command -v docker &>/dev/null; then
+  echo ">>> Installing Docker..."
+  curl -fsSL https://get.docker.com | sh
+  usermod -aG docker "$OPENCLAW_USER"
+  systemctl enable --now docker
+else
+  echo ">>> Docker $(docker --version | cut -d' ' -f3 | tr -d ',') already installed"
+fi
+
+# ── 3. Tailscale VPN ──────────────────────────────────────────────
 if ! command -v tailscale &>/dev/null; then
   echo ">>> Installing Tailscale..."
   curl -fsSL https://tailscale.com/install.sh | sh


### PR DESCRIPTION
## Summary
- Adds Docker CE install to `install.sh` for OpenClaw sandbox tool execution
- Adds `openclaw` user to `docker` group
- Idempotent — skips if Docker already installed

## Context
OpenClaw agents fail with `Sandbox mode requires Docker` when executing tools. Docker is required for sandboxed tool execution.

## Test plan
- [x] Docker installed on all 3 VMs (orchestrator, sugato, casa-gourmet) 
- [ ] Verify OpenClaw sandbox tool execution works after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)