### PR TITLE
feat(sugato): whatsapp channel + sync fixes + lucia sales agent

### DIFF
--- a/config/base.jsonc
+++ b/config/base.jsonc
@@ -39,6 +39,21 @@
   "cron": {
     "enabled": true
   },
+  // Gateway — accessible via Tailscale for admin dashboard access.
+  // Tailnet origins use wildcard to cover all 100.x.y.z Tailscale IPs.
+  // New tenants inherit this automatically.
+  "gateway": {
+    "port": 8080,
+    "mode": "local",
+    "bind": "lan",
+    "controlUi": {
+      "allowedOrigins": ["*"]
+    },
+    "auth": {
+      "mode": "token",
+      "token": "${OPENCLAW_GATEWAY_TOKEN}"
+    }
+  },
   "logging": {
     "level": "info",
     "redactSensitive": "tools"

--- a/config/tenants/casa-gourmet.jsonc
+++ b/config/tenants/casa-gourmet.jsonc
@@ -9,7 +9,34 @@
           "network": "bridge"
         }
       }
-    }
+    },
+    "list": [
+      {
+        "id": "main"
+      },
+      {
+        "id": "lucia",
+        "name": "Lucia",
+        "workspace": "/home/openclaw/.openclaw/workspace/agents/lucia",
+        "agentDir": "/home/openclaw/.openclaw/agents/lucia/agent",
+        "model": {
+          "primary": "openai/gpt-5-nano"
+        },
+        "tools": {
+          "profile": "messaging",
+          "deny": ["gateway", "cron", "group:nodes", "bash", "browser"]
+        },
+        "subagents": {
+          "allowAgents": []
+        },
+        "routing": [
+          {
+            "channel": "telegram",
+            "account": "lucia"
+          }
+        ]
+      }
+    ]
   },
   "channels": {
     "telegram": {
@@ -21,7 +48,18 @@
       ],
       "groupPolicy": "disabled",
       "groupAllowFrom": [],
-      "streaming": "partial"
+      "streaming": "partial",
+      // Lucia's separate Telegram bot
+      "accounts": {
+        "lucia": {
+          "botToken": "${LUCIA_TELEGRAM_BOT_TOKEN}",
+          "enabled": true,
+          "dmPolicy": "allowlist",
+          "allowFrom": [6041283426],
+          "groupPolicy": "disabled",
+          "streaming": "partial"
+        }
+      }
     }
   },
 

--- a/config/tenants/sugato.jsonc
+++ b/config/tenants/sugato.jsonc
@@ -16,7 +16,13 @@
   },
 
   "channels": {
-    "defaults": {}
+    "defaults": {},
+    // WhatsApp: dedicated number, pairing-based DM access
+    "whatsapp": {
+      "enabled": true,
+      "dmPolicy": "pairing",
+      "groupPolicy": "allowlist"
+    }
   },
 
   // Mem0: per-tenant memory isolation

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,25 @@ echo ">>> Installing base dependencies..."
 apt-get update -qq
 apt-get install -y -qq curl git jq
 
-# ── 2. Cloud SQL Auth Proxy ─────────────────────────────────────────
+# ── 2. Docker (required for OpenClaw sandbox) ─────────────────────
+if ! command -v docker &>/dev/null; then
+  echo ">>> Installing Docker..."
+  curl -fsSL https://get.docker.com | sh
+  usermod -aG docker "$OPENCLAW_USER"
+  systemctl enable --now docker
+else
+  echo ">>> Docker $(docker --version | cut -d' ' -f3 | tr -d ',') already installed"
+fi
+
+# ── 3. Tailscale VPN ──────────────────────────────────────────────
+if ! command -v tailscale &>/dev/null; then
+  echo ">>> Installing Tailscale..."
+  curl -fsSL https://tailscale.com/install.sh | sh
+else
+  echo ">>> Tailscale $(tailscale version | head -1) already installed"
+fi
+
+# ── 3. Cloud SQL Auth Proxy ─────────────────────────────────────────
 if ! command -v cloud-sql-proxy &>/dev/null; then
   echo ">>> Installing Cloud SQL Auth Proxy..."
   curl -sSfL -o /usr/local/bin/cloud-sql-proxy \
@@ -87,10 +105,12 @@ echo "$TENANT_ID" > /etc/openclaw/tenant-id
 
 # ── 7. Create secrets env file ──────────────────────────────────────
 if [[ ! -f /etc/openclaw/env ]]; then
-  echo "# Secrets — populate from GCP Secret Manager" > /etc/openclaw/env
-  echo "# GEMINI_API_KEY=" >> /etc/openclaw/env
-  echo "# OPENAI_API_KEY=" >> /etc/openclaw/env
-  echo "# TELEGRAM_BOT_TOKEN=" >> /etc/openclaw/env
+  {
+    echo "# Secrets — populate from GCP Secret Manager"
+    echo "# GEMINI_API_KEY="
+    echo "# OPENAI_API_KEY="
+    echo "# TELEGRAM_BOT_TOKEN="
+  } > /etc/openclaw/env
   chmod 600 /etc/openclaw/env
 fi
 
@@ -236,10 +256,29 @@ systemctl start pesuclaw-update.timer
 systemctl enable openclaw-backup.timer
 systemctl start openclaw-backup.timer
 
-# ── 10. Install mem0 plugin ─────────────────────────────────────────
+# ── 10. Join Tailscale network ─────────────────────────────────────
+echo ">>> Joining Tailscale network..."
+if tailscale status &>/dev/null 2>&1; then
+  echo "  Already connected to Tailnet"
+else
+  TS_AUTHKEY=$(gcloud secrets versions access latest \
+    --secret="${TENANT_ID}-tailscale-authkey" \
+    --project=sugato-489514 2>/dev/null || true)
+  if [[ -n "$TS_AUTHKEY" ]]; then
+    tailscale up --authkey="$TS_AUTHKEY" --hostname="vm-${TENANT_ID}" --accept-routes
+    echo "  Joined Tailnet as vm-${TENANT_ID}"
+    # Expose OpenClaw gateway over HTTPS via Tailscale Serve
+    tailscale serve --bg http://localhost:8080
+    echo "  HTTPS dashboard: https://vm-${TENANT_ID}.chimp-ulmer.ts.net/"
+  else
+    echo "  Warning: No Tailscale auth key found in Secret Manager"
+    echo "  Create secret '${TENANT_ID}-tailscale-authkey' and run: tailscale up --authkey=<key> --hostname=vm-${TENANT_ID}"
+  fi
+fi
+
+# ── 11. Install mem0 plugin ─────────────────────────────────────────
 echo ">>> Installing mem0 memory plugin..."
 su - "$OPENCLAW_USER" -c "openclaw plugins install @mem0/openclaw-mem0" 2>/dev/null || {
-  log_path=$(which openclaw 2>/dev/null || echo "/usr/local/bin/openclaw")
   echo "  Warning: mem0 plugin install failed (openclaw may not be installed yet)"
   echo "  sync.sh will retry on first run"
 }

--- a/manifests/casa-gourmet.yaml
+++ b/manifests/casa-gourmet.yaml
@@ -5,7 +5,7 @@
 tenant_id: casa-gourmet
 instance_type: client
 
-openclaw_version: '2026.3.8'
+openclaw_version: latest
 
 workspace_template: casa-gourmet
 
@@ -22,6 +22,16 @@ skills:
   - youtube-transcript
   # Client-specific:
   # - whatsapp-sales
+
+# Secrets from GCP Secret Manager → /etc/openclaw/env
+# Format: secret-name: ENV_VAR_NAME
+secrets:
+  casa-gourmet-gemini-api-key: GEMINI_API_KEY
+  casa-gourmet-openai-api-key: OPENAI_API_KEY
+  casa-gourmet-telegram-bot-token: TELEGRAM_BOT_TOKEN
+  casa-gourmet-db-password: DB_PASSWORD
+  casa-gourmet-lucia-telegram-bot-token: LUCIA_TELEGRAM_BOT_TOKEN
+  casa-gourmet-lucia-openai-api-key: LUCIA_OPENAI_API_KEY
 
 packages:
   - jq

--- a/manifests/orchestrator.yaml
+++ b/manifests/orchestrator.yaml
@@ -19,6 +19,12 @@ skills:
   - memory-forget
   - memory-reflect
 
+# Secrets from GCP Secret Manager → /etc/openclaw/env
+secrets:
+  orchestrator-gemini-api-key: GEMINI_API_KEY
+  orchestrator-openai-api-key: OPENAI_API_KEY
+  orchestrator-db-password: DB_PASSWORD
+
 packages:
   - jq
   - curl

--- a/manifests/sugato.yaml
+++ b/manifests/sugato.yaml
@@ -24,6 +24,13 @@ skills:
   - memory-forget
   - memory-reflect
 
+# Secrets from GCP Secret Manager → /etc/openclaw/env
+secrets:
+  sugato-gemini-api-key: GEMINI_API_KEY
+  sugato-openai-api-key: OPENAI_API_KEY
+  sugato-telegram-bot-token: TELEGRAM_BOT_TOKEN
+  sugato-db-password: DB_PASSWORD
+
 # System packages (apt) — only installed if missing
 packages:
   - jq

--- a/sync.sh
+++ b/sync.sh
@@ -88,7 +88,8 @@ log "Reconciling tenant: $TENANT_ID"
 log "  Desired OpenClaw: $DESIRED_VERSION"
 
 # ── 2. Reconcile OpenClaw version ─────────────────────────────────────
-CURRENT_VERSION=$(openclaw --version 2>/dev/null || echo "not-installed")
+# Extract semver only: "OpenClaw 2026.3.13 (61d171a)" -> "2026.3.13"
+CURRENT_VERSION=$(openclaw --version 2>/dev/null | awk '{print $2}' || echo "not-installed")
 
 if [[ "$DESIRED_VERSION" == "latest" ]]; then
   # Check if an update is available
@@ -382,6 +383,30 @@ $include_lines
 }
 SEED
 }
+
+# ── Reconcile secrets from GCP Secret Manager ─────────────────────────
+# Reads secrets: map from manifest (secret-name: ENV_VAR) and ensures
+# each is present in /etc/openclaw/env. Only fetches missing ones.
+SECRETS_BLOCK=$(awk '/^secrets:/{found=1; next} found && /^[^ ]/{exit} found && /^ /{print}' "$MANIFEST")
+if [[ -n "$SECRETS_BLOCK" ]]; then
+  while IFS=': ' read -r secret_name env_var; do
+    # Skip empty lines and comments
+    [[ -z "$secret_name" || "$secret_name" == \#* ]] && continue
+    # Trim leading spaces from YAML indent
+    secret_name=$(echo "$secret_name" | xargs)
+    env_var=$(echo "$env_var" | xargs)
+    if ! grep -q "^${env_var}=" /etc/openclaw/env 2>/dev/null; then
+      SECRET_VAL=$(gcloud secrets versions access latest --secret="$secret_name" --project=sugato-489514 2>/dev/null || true)
+      if [[ -n "$SECRET_VAL" ]]; then
+        echo "${env_var}=${SECRET_VAL}" >> /etc/openclaw/env
+        log "  Provisioned secret: $env_var"
+        changed=1
+      else
+        log "  Warning: secret '$secret_name' not found in Secret Manager"
+      fi
+    fi
+  done <<< "$SECRETS_BLOCK"
+fi
 
 # Generate a local gateway token if not present
 if ! grep -q "^OPENCLAW_GATEWAY_TOKEN=" /etc/openclaw/env; then

--- a/workspace-templates/casa-gourmet/AGENTS.md
+++ b/workspace-templates/casa-gourmet/AGENTS.md
@@ -1,0 +1,4 @@
+# Agentes
+
+Este workspace tiene un único agente: Lucia (ventas).
+No hay subagentes disponibles. Todas las consultas son manejadas por Lucia.

--- a/workspace-templates/casa-gourmet/IDENTITY.md
+++ b/workspace-templates/casa-gourmet/IDENTITY.md
@@ -1,0 +1,8 @@
+# Identidad
+
+- **Nombre**: Lucia
+- **Rol**: Asistente de Ventas
+- **Empresa**: Casa Gourmet
+- **Idioma**: Español (exclusivamente)
+- **Tono**: Profesional, cálido, directo
+- **Objetivo**: Calificar leads, presentar productos, cerrar ventas o derivar a humano

--- a/workspace-templates/casa-gourmet/SOUL.md
+++ b/workspace-templates/casa-gourmet/SOUL.md
@@ -1,0 +1,63 @@
+# Lucia — Asistente de Ventas de Casa Gourmet
+
+## Identidad
+
+Eres Lucia, la asistente de ventas de Casa Gourmet. Tu único propósito es atender consultas sobre productos, guiar conversaciones de venta, y cerrar o derivar a un humano cuando sea necesario.
+
+## Idioma
+
+SIEMPRE respondés en español. Si alguien te escribe en otro idioma, respondé amablemente en español que solo podés atender en ese idioma.
+
+## Personalidad
+
+- Cálida, profesional y directa
+- Conocedora de los productos de Casa Gourmet
+- Paciente con las preguntas pero enfocada en avanzar la venta
+- Nunca agresiva ni insistente — guiás con información y empatía
+
+## Límites Estrictos
+
+### LO QUE SÍ HACÉS:
+- Responder preguntas sobre productos, precios, disponibilidad y entregas
+- Calificar leads: entender qué necesita el cliente, presupuesto, ubicación, urgencia
+- Manejar objeciones comunes (precio, timing, comparación con competencia)
+- Ofrecer promociones y descuentos SOLO los que estén autorizados
+- Cerrar ventas o agendar seguimiento
+- Derivar a un humano cuando sea necesario
+
+### LO QUE NUNCA HACÉS:
+- Hablar de temas que no sean productos o ventas de Casa Gourmet
+- Inventar información sobre productos, precios o promociones
+- Ofrecer descuentos no autorizados
+- Dar opiniones políticas, religiosas, personales o sobre cualquier tema fuera de tu rol
+- Ejecutar código, acceder a sistemas externos, o realizar acciones técnicas
+- Responder en otro idioma que no sea español
+
+### ANTE PREGUNTAS FUERA DE TEMA:
+Respondé siempre con una variación de:
+"¡Gracias por tu mensaje! Soy Lucia, asistente de ventas de Casa Gourmet. Solo puedo ayudarte con consultas sobre nuestros productos y pedidos. ¿Te puedo ayudar con algo de nuestra tienda?"
+
+## Flujo de Conversación
+
+1. **Saludo** → Presentarte brevemente, preguntar en qué podés ayudar
+2. **Calificación** → Entender qué busca, para qué, presupuesto aproximado, ubicación
+3. **Presentación** → Recomendar productos relevantes con precios
+4. **Objeciones** → Manejar con información y empatía
+5. **Cierre** → Confirmar pedido o agendar seguimiento
+6. **Derivación** → Si no podés resolver, derivar con contexto completo
+
+## Criterios de Derivación a Humano
+
+Derivá INMEDIATAMENTE cuando:
+- El cliente pide un descuento excepcional o fuera de política
+- La conversación se pone tensa o el cliente está frustrado
+- Hay un reclamo o problema con un pedido existente
+- El cliente pide hablar con una persona
+- Hay temas legales, de pago, o devoluciones complejas
+- Es un lead de alto valor (pedidos mayoristas, eventos, corporativos)
+
+Al derivar, incluí:
+- Resumen del cliente y su necesidad
+- Productos discutidos
+- Objeciones planteadas
+- Tu recomendación de siguiente paso


### PR DESCRIPTION
## Summary
- Replace Telegram with WhatsApp channel on vm-sugato (pairing mode, dedicated number)
- Fix sync preventing openclaw reinstall every 5 minutes
- Add mem0 plugin slot to config template
- Fix mem0 plugin packaging and ReadWritePaths
- Add Lucia sales agent for Casa Gourmet
- Add secret auto-provisioning from Secret Manager
- Add Docker + Tailscale support

## Test plan
- [ ] Merge to master → `sync.sh --tenant sugato` on vm-sugato picks up WhatsApp config
- [ ] Run `sudo -u openclaw openclaw channels login --channel whatsapp` to link the dedicated number via QR
- [ ] Confirm Telegram no longer starts on vm-sugato
- [ ] Confirm mem0 still initializes after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)