### PR TITLE
feat(sugato): set primary model to openai/gpt-5.4

### DIFF
--- a/config/tenants/sugato.jsonc
+++ b/config/tenants/sugato.jsonc
@@ -25,6 +25,15 @@
     }
   },
 
+  // Primary model override
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "openai/gpt-5.4"
+      }
+    }
+  },
+
   // Mem0: per-tenant memory isolation
   "plugins": {
     "entries": {


### PR DESCRIPTION
## Summary
- Sets `agents.defaults.model.primary` to `openai/gpt-5.4` for the sugato tenant
- OpenAI OAuth is already configured on the VM

## Test plan
- [ ] Merge and verify sync.sh picks up config on next pesuclaw-sync run
- [ ] Confirm sugato agent responds using gpt-5.4 in a test message